### PR TITLE
Fix Deprecation Warning in Keymaps

### DIFF
--- a/keymaps/close-tags.cson
+++ b/keymaps/close-tags.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'alt-cmd-.': 'close-tags:close'


### PR DESCRIPTION
'.editor' is deprected in keymaps, use 'atom-text-editor' instead
